### PR TITLE
Fixed some typos and edited some of the code to reduce warnings.

### DIFF
--- a/exercises/06-fn-annotations.mojo
+++ b/exercises/06-fn-annotations.mojo
@@ -6,7 +6,7 @@
 #   We've seen function annations before in a previous exercise, so
 #   this one should be super easy!
 #
-#   Remember, when we `fn` functions, all arguments are return types
+#   Remember, when we `fn` functions, all arguments and return types
 #   need annotations. If no return type annotation is given, it defaults
 #   to `None`.
 #

--- a/exercises/07-fn-raises.mojo
+++ b/exercises/07-fn-raises.mojo
@@ -22,10 +22,10 @@ from testing import assert_equal
 
 fn main() raises:
     var num: Int = 10
-    assert_equal(num, 10)
+    _ = assert_equal(num, 10)
 
     num = num * 2
-    check_if_twenty(num)
+    _ = check_if_twenty(num)
 
 
 fn check_if_twenty(num: Int):

--- a/exercises/07-fn-raises.mojo
+++ b/exercises/07-fn-raises.mojo
@@ -4,7 +4,7 @@
 # Core Concept:
 #
 #   One final note on `fn` functions. If the body of the 
-#   function might raising an exception, we need to explicitly
+#   function might raise an exception, we need to explicitly
 #   label the function with the "raises" keyword (see the main
 #   function for an example).
 #

--- a/exercises/08-quiz-1.mojo
+++ b/exercises/08-quiz-1.mojo
@@ -16,14 +16,14 @@ fn main() raises:
     result = add_two(start)
     result = add_three(result)
 
-    assert_equal(result, 5)
+    _ = assert_equal(result, 5)
 
     alias msg: String = "You've completed Quiz 1!"
     print_msg(msg)
 
 
 fn add_two(n) raises:
-    assert_not_equal(n, -1)
+    _ = assert_not_equal(n, -1)
     return n + 2
 
 

--- a/solutions/06-fn-annotations.mojo
+++ b/solutions/06-fn-annotations.mojo
@@ -6,7 +6,7 @@
 #   We've seen function annations before in a previous exercise, so
 #   this one should be super easy!
 #
-#   Remember, when we `fn` functions, all arguments are return types
+#   Remember, when we `fn` functions, all arguments and return types
 #   need annotations. If no return type annotation is given, it defaults
 #   to `None`.
 #

--- a/solutions/07-fn-raises.mojo
+++ b/solutions/07-fn-raises.mojo
@@ -22,11 +22,11 @@ from testing import assert_equal
 
 fn main() raises:
     var num: Int = 10
-    assert_equal(num, 10)
+    _ = assert_equal(num, 10)
 
     num = num * 2
     check_if_twenty(num)
 
 
 fn check_if_twenty(num: Int) raises:
-    assert_equal(num, 20)
+    _ = assert_equal(num, 20)

--- a/solutions/07-fn-raises.mojo
+++ b/solutions/07-fn-raises.mojo
@@ -4,7 +4,7 @@
 # Core Concept:
 #
 #   One final note on `fn` functions. If the body of the 
-#   function might raising an exception, we need to explicitly
+#   function might raise an exception, we need to explicitly
 #   label the function with the "raises" keyword (see the main
 #   function for an example).
 #

--- a/solutions/08-quiz-1.mojo
+++ b/solutions/08-quiz-1.mojo
@@ -16,14 +16,14 @@ fn main() raises:
     result = add_two(start)
     result = add_three(result)
 
-    assert_equal(result, 5)
+    _ = assert_equal(result, 5)
 
     var msg: String = "You've completed Quiz 1!"
     print_msg(msg)
 
 
 fn add_two(n: Int) raises -> Int:
-    assert_not_equal(n, -1)
+    _ = assert_not_equal(n, -1)
     return n + 2
 
 


### PR DESCRIPTION
I noticed some typos in the exercise descriptions. I fixed them both in the exercises and solutions folders.

Mojo was also giving me some complaints about the bool returned by assert_equal in lessons 07 and 08. I changed the code to read `_ = assert_equal(...)` to make the compiler happy.